### PR TITLE
Fixed Crashes wile parsing metadata of collections

### DIFF
--- a/src/main/java/eu/openeo/api/impl/CollectionsApiServiceImpl.java
+++ b/src/main/java/eu/openeo/api/impl/CollectionsApiServiceImpl.java
@@ -77,8 +77,13 @@ public class CollectionsApiServiceImpl extends CollectionsApiService {
 			Element coverageDescElement = rootNode.getChild("CoverageDescription", defaultNS);
 			Element boundedByElement = coverageDescElement.getChild("boundedBy", gmlNS);
 			Element boundingBoxElement = boundedByElement.getChild("Envelope", gmlNS);
-			Element metadataElement = rootNode.getChild("CoverageDescription", defaultNS).getChild("metadata", gmlNS).getChild("Extension", gmlNS).getChild("covMetadata", gmlNS);
-			
+			Element metadataElement = null;
+			try {
+			metadataElement = rootNode.getChild("CoverageDescription", defaultNS).getChild("metadata", gmlNS).getChild("Extension", gmlNS).getChild("covMetadata", gmlNS);
+		    }catch(Exception e) {
+			log.error("Error in parsing bands :" + e.getMessage());
+		    }
+		
 			List<Element> bandsList = null;
 			Boolean bandsMeta = false;
 			try {


### PR DESCRIPTION
more stable handling of collections with incomplete metadata to avoid server crashed when reading incomplete sets